### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,8 @@
 
 
 name: Build and Test
+permissions:
+  contents: read
 
 on:
   push:

--- a/pom.xml
+++ b/pom.xml
@@ -262,9 +262,11 @@
                             <gpgArguments>
                                 <arg>--pinentry-mode</arg>
                                 <arg>loopback</arg>
-                                <arg>--batch</arg>
+                                <arg>--batch</arg>        
+                                <arg>--no-tty</arg>        
                                 <arg>--yes</arg>
                             </gpgArguments>
+                            <passphrase>${GPG_PASSPHRASE}</passphrase>
                         </configuration>
                     </plugin>
 

--- a/src/main/java/com/ricardo/auth/config/SecurityConfig.java
+++ b/src/main/java/com/ricardo/auth/config/SecurityConfig.java
@@ -1,7 +1,5 @@
 package com.ricardo.auth.config;
 
-import com.ricardo.auth.security.JwtAuthFilter;
-import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +14,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.ricardo.auth.security.JwtAuthFilter;
+
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * The type Security config.
@@ -72,6 +74,12 @@ public class SecurityConfig {
      */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        // SECURITY NOTE: CSRF protection disabled for JWT-based stateless API
+        // This is safe because:
+        // 1. No session cookies (SessionCreationPolicy.STATELESS)
+        // 2. JWT tokens require explicit Authorization header
+        // 3. Malicious sites cannot access JWT tokens due to browser security
+        // 4. No traditional form-based authentication endpoints
         return http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         // Apenas login e registo são públicos


### PR DESCRIPTION
Potential fix for [https://github.com/RicardoMorim/Auth-Provider/security/code-scanning/3](https://github.com/RicardoMorim/Auth-Provider/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations:
- `contents: read` is required to check out the repository code.
- No other permissions appear necessary for the current workflow tasks.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `build` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
